### PR TITLE
Refactor: Display raw API response on results page

### DIFF
--- a/src/components/ProductScanner.tsx
+++ b/src/components/ProductScanner.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { Textarea } from "@/components/ui/textarea"; // Added import
+// Textarea import removed as it's no longer used
 import { Camera } from "lucide-react";
 import { ProductData } from "@/types/product";
 import { useToast } from "@/components/ui/use-toast";
@@ -12,7 +12,7 @@ import { ProcessingIndicator } from "./scanner/ProcessingIndicator";
 import { processImageWithType } from "@/utils/imageProcessingUtils";
 
 interface ProductScannerProps {
-  onProductsDetected: (products: ProductData[]) => void;
+  onProductsDetected: (products: ProductData[], rawResponse: string) => void;
   onCancel: () => void;
 }
 
@@ -24,7 +24,7 @@ const ProductScanner: React.FC<ProductScannerProps> = ({
   const [capturedImage, setCapturedImage] = useState<string | null>(null);
   const [imageType, setImageType] = useState<string | null>(null);
   const [showCamera, setShowCamera] = useState(false);
-  const [rawApiResponse, setRawApiResponse] = useState<string | null>(null); // Added state
+  // rawApiResponse state removed
   const { toast } = useToast();
 
   const handleCameraCapture = (imageData: string) => {
@@ -47,8 +47,8 @@ const ProductScanner: React.FC<ProductScannerProps> = ({
           title: "Analysis Complete",
           description: `Found ${products.length} products on the shelf!`,
         });
-        onProductsDetected(products);
-        setRawApiResponse(rawResponse); // Added line
+        onProductsDetected(products, rawResponse); // Updated call
+        // setRawApiResponse removed
       },
       () => {
         toast({
@@ -78,8 +78,8 @@ const ProductScanner: React.FC<ProductScannerProps> = ({
           title: "Analysis Complete",
           description: `Found ${products.length} ${detectedType} products!`,
         });
-        onProductsDetected(products);
-        setRawApiResponse(rawResponse); // Added line
+        onProductsDetected(products, rawResponse); // Updated call
+        // setRawApiResponse removed
       },
       () => {
         toast({
@@ -129,17 +129,7 @@ const ProductScanner: React.FC<ProductScannerProps> = ({
         <ProcessingIndicator imageType={imageType} />
       )}
 
-      {rawApiResponse && (
-        <div className="mt-4">
-          <h4 className="font-medium mb-2">Raw API Response (for debugging):</h4>
-          <Textarea
-            readOnly
-            value={rawApiResponse}
-            className="w-full h-48 text-xs"
-            placeholder="Raw API response will appear here..."
-          />
-        </div>
-      )}
+      {/* Raw API Response display removed */}
 
       <div className="flex justify-center mt-4">
         <Button variant="outline" onClick={onCancel} className="mr-2">Cancel</Button>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea"; // Added import
 import ProductScanner from "@/components/ProductScanner";
 import ProductDisplay from "@/components/ProductDisplay";
 import SpreadsheetExport from "@/components/SpreadsheetExport";
@@ -9,9 +10,11 @@ import { ProductData } from "@/types/product";
 const Index = () => {
   const [scannedProducts, setScannedProducts] = useState<ProductData[]>([]);
   const [isScanning, setIsScanning] = useState(false);
+  const [lastRawApiResponse, setLastRawApiResponse] = useState<string | null>(null); // Added state
 
-  const handleProductsDetected = (products: ProductData[]) => {
+  const handleProductsDetected = (products: ProductData[], rawResponse: string) => { // Updated signature
     setScannedProducts((prev) => [...prev, ...products]);
+    setLastRawApiResponse(rawResponse); // Added line
     setIsScanning(false);
   };
 
@@ -54,6 +57,17 @@ const Index = () => {
             <div className="mt-8">
               <SpreadsheetExport products={scannedProducts} />
             </div>
+            {lastRawApiResponse && (
+              <div className="mt-8">
+                <h3 className="text-lg font-semibold mb-2">Raw API Response (for debugging):</h3>
+                <Textarea
+                  readOnly
+                  value={lastRawApiResponse}
+                  className="w-full h-60 text-xs bg-gray-50"
+                  placeholder="Raw API response..."
+                />
+              </div>
+            )}
           </>
         )}
       </div>


### PR DESCRIPTION
This commit revises the temporary feature for displaying the raw API response for debugging purposes.

Changes:
- `ProductScanner.tsx` now passes the raw API response string via its `onProductsDetected` prop. The local display within ProductScanner has been removed.
- `Index.tsx` (the main page) now accepts this raw response in its `handleProductsDetected` function, stores it in a new state variable `lastRawApiResponse`.
- A textarea has been added to `Index.tsx` to display `lastRawApiResponse` on the same view where scanned products are shown.

This ensures the raw response is visible even after `ProductScanner` unmounts, allowing you to copy it in successful detection scenarios.